### PR TITLE
add helper script to generate rails specfile templates

### DIFF
--- a/generate_railsapp_spec.sh
+++ b/generate_railsapp_spec.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+#
+# Helper script for rails apps to create a spec file from a template
+#
+# To use this script, the folder structucture in your rails project needs to look like
+# /RAILS_ROOT 
+#   -> /packaging
+#     -> /suse
+#       -> /patches # place patches here
+#         -> 0_downgrade_rails.gem.patch
+#         -> 1_suse_only_fix.rpm.patch
+#       -> generate_railsapp_spec.sh
+#       -> ${project_name}.spec.in # this is the specfile template
+#
+# The template ${project_name}.spec.in can include the following placeholders:
+# __BRANCH__
+# __RUBYGEMS_BUILD_REQUIRES__
+# __DATE__
+# __COMMIT__
+# __VERSION__
+# __CURRENT_YEAR__
+# __PATCHSOURCES__
+# __PATCHEXECS__
+#
+# Place them at the correct section and they will get expanded
+#
+# Example spec:
+#
+# #
+# # spec file for package $1
+# #
+# # Copyright (c) __CURRENT_YEAR__ SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Name:           $1
+# Version:        __VERSION__
+# %define branch __BRANCH__
+# Url:            https://github.com/some/$1
+# Source:         %{branch}.tar.gz
+# __PATCHSOURCES__
+# Requires:       ruby >= 2.1
+# __RUBYGEMS_BUILD_REQUIRES__
+# %description
+# This package has been built with commit __COMMIT__ from branch __BRANCH__ on date __DATE__
+# %prep
+# %setup -q -n $1-%{branch}
+# __PATCHEXECS__
+# %build
+# %install
+# %files
+
+if [ -z "$1" ]; then
+  cat <<EOF
+usage:
+  ./generate_railsapp_spec.sh PACKAGENAME
+EOF
+  exit 1
+fi
+
+packagename=$1
+
+bundle version 2>/dev/null
+if [ $? != 0 ];then
+  echo "bundler is not installed. Please install it."
+  exit -1
+fi
+cd $(dirname $0)
+
+if [ $TRAVIS_BRANCH ];then
+  branch=$TRAVIS_BRANCH
+else
+  branch=$(git rev-parse --abbrev-ref HEAD)
+fi
+if [ $TRAVIS_COMMIT ];then
+  commit=$TRAVIS_COMMIT
+else
+  commit=$(git rev-parse HEAD)
+fi
+version=$(sed s/-/~/g ../../VERSION)
+version="$version+git$commit"
+date=$(date --rfc-2822)
+year=$(date +%Y)
+
+# clean
+[ ! -d build ] || rm -rf build
+
+additional_native_build_requirements() {
+  if [ $1 == "nokogiri" ];then
+    echo "BuildRequires: libxml2-devel libxslt-devel\n"
+  elif [ $1 == "mysql2" ];then
+    echo "BuildRequires: libmysqlclient-devel < 10.1\nRequires: libmysqlclient18 < 10.1\nRecommends: mariadb\n"
+  elif [ $1 == "ethon" ];then
+    echo "BuildRequires: libcurl-devel\nRequires: libcurl4\n"
+  elif [ $1 == "ffi" ];then
+    echo "BuildRequires: libffi-devel\n"
+  fi
+}
+
+mkdir -p build/$packagename-$branch
+cp -v ../../Gemfile* build/$packagename-$branch
+cp -v patches/*.patch build/$packagename-$branch
+
+pushd build/$packagename-$branch/
+  echo "apply patches if needed"
+  if ls *.patch >/dev/null 2>&1 ;then
+      for p in *.patch;do
+          number=$(echo "$p" | cut -d"_" -f1)
+          patchsources="$patchsources\nPatch$number: $p\n"
+          patchexecs="$patchexecs\n%patch$number -p1\n"
+          # skip applying rpm patches
+          [[ $p =~ .rpm\.patch$ ]] && continue
+          echo "applying patch $p"
+          patch -p1 < $p || exit -1
+      done
+  fi
+  echo "generate the Gemfile.lock for packaging"
+  export BUNDLE_GEMFILE=$PWD/Gemfile
+  cp Gemfile.lock Gemfile.lock.orig
+  bundle config build.nokogiri --use-system-libraries
+  PACKAGING=yes bundle install --retry=3 --no-deployment
+  grep "git-review" Gemfile.lock
+  if [ $? == 0 ];then
+    echo "DEBUG: ohoh something went wrong and you have devel packages"
+    diff Gemfile.lock Gemfile.lock.orig
+    exit -1
+  fi
+  echo "get requirements from Gemfile.lock"
+  IFS=$'\n' # do not split on spaces
+  build_requires=""
+  for gem in $(cat Gemfile.lock | grep "    "  | grep "     " -v | sort | uniq);do
+    gem_name=$(echo $gem | cut -d" " -f5)
+    gem_version=$(echo $gem | cut -d "(" -f2 | cut -d ")" -f1)
+    build_requires="$build_requires\nBuildRequires: %{rubygem $gem_name} = $gem_version"
+    build_requires="$build_requires\n$(additional_native_build_requirements $gem_name)"
+  done
+popd
+
+echo "create ${packagename}.spec based on ${packagename}.spec.in"
+cp ${packagename}.spec.in ${packagename}.spec
+sed -e "s/__BRANCH__/$branch/g" -i ${packagename}.spec
+sed -e "s/__RUBYGEMS_BUILD_REQUIRES__/$build_requires/g" -i ${packagename}.spec
+sed -e "s/__DATE__/$date/g" -i ${packagename}.spec
+sed -e "s/__COMMIT__/$commit/g" -i ${packagename}.spec
+sed -e "s/__VERSION__/$version/g" -i ${packagename}.spec
+sed -e "s/__CURRENT_YEAR__/$year/g" -i ${packagename}.spec
+sed -e "s/__PATCHSOURCES__/$patchsources/g" -i ${packagename}.spec
+sed -e "s/__PATCHEXECS__/$patchexecs/g" -i ${packagename}.spec
+
+if [ -f ${packagename}.spec ];then
+  echo "Done!"
+  exit 0
+else
+  echo "A problem occured creating the spec file."
+  exit -1
+fi


### PR DESCRIPTION
this helps with the typical rails packaging and is currently used
by portus, and will be used by kubic-project/velum as well to help
with the suse specific packaging.

for not having to maintain the same code in 2 different repos i'd
like to add it to the general suse ruby-packaging repo and reference
it in portus and velum from there.

## see portus repo
https://github.com/SUSE/Portus/blob/master/packaging/suse/make_spec.sh