### PR TITLE
add fix_sheb macro for those cases where we don't install the default

### DIFF
--- a/ruby-common.macros
+++ b/ruby-common.macros
@@ -22,12 +22,14 @@
 %rubydevelxSTOP() %*
 #
 
-%fix_sheb() \
-  for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | sort | uniq);do\
-    sed -e 's|^#!/usr/bin/env ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
-  done;\
-  for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | sort | uniq);do\
-     sed -e 's|^#!/usr/bin/ruby$|#!/usr/bin/ruby.ruby2.5|g' -i $i;\
-  done;\
+%rb_fix_shebang() \
+  if [ "%{rb_suffix}" != "" ];then \
+    for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+      sed -e 's|^#!/usr/bin/env ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
+    done;\
+    for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+       sed -e 's|^#!/usr/bin/ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
+    done;\
+  fi; \
 %{nil}
 

--- a/ruby-common.macros
+++ b/ruby-common.macros
@@ -21,3 +21,13 @@
 %rubydevelSTOP() %nil
 %rubydevelxSTOP() %*
 #
+
+%fix_sheb() \
+  for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+    sed -e 's|^#!/usr/bin/env ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
+  done;\
+  for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+     sed -e 's|^#!/usr/bin/ruby$|#!/usr/bin/ruby.ruby2.5|g' -i $i;\
+  done;\
+%{nil}
+


### PR DESCRIPTION
ruby

When not installing the default ruby, the file /usr/bin/ruby does not
exist. For example installing ruby2.5 when the default is 2.1.

Thus, we need to replace "/usr/bin/ruby" by "/usr/bin/ruby.rubyX.Y". In a
similar fashion, "/usr/bin/env" ruby should be "/usr/bin/ruby.rubyX.Y".

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>